### PR TITLE
Set the Default Storage_Engine to RocksDB

### DIFF
--- a/InstanceManager.js
+++ b/InstanceManager.js
@@ -17,15 +17,7 @@ exports.create = () => {
     );
   }
 
-  let storageEngine;
-  if (process.env.ARANGO_STORAGE_ENGINE) {
-    storageEngine = process.env.ARANGO_STORAGE_ENGINE;
-    if (storageEngine !== "rocksdb") {
-      storageEngine = "mmfiles";
-    }
-  } else {
-    storageEngine = "mmfiles";
-  }
+  let storageEngine = process.env.ARANGO_STORAGE_ENGINE === "mmfiles" ? "mmfiles"  : "rocksdb";
   return new aim.InstanceManager(pathOrImage, runner, storageEngine);
 };
 


### PR DESCRIPTION
This will set the Default Storage Engine to RocksDB instead of MMFiles.
As soon as all MMFiles versions are EOL we can simply remove this and replace by a constant value.

